### PR TITLE
Update version to 4.3.1-3 and implement click suppression in MediaClipSelector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@AnokiAI/media-chrome",
-  "version": "4.3.1-2",
+  "version": "4.3.1-3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@AnokiAI/media-chrome",
-      "version": "4.3.1-2",
+      "version": "4.3.1-3",
       "license": "MIT",
       "devDependencies": {
         "@custom-elements-manifest/analyzer": "^0.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@AnokiAI/media-chrome",
-  "version": "4.3.1-2",
+  "version": "4.3.1-3",
   "description": "Custom elements (web components) for making audio and video player controls that look great in your website or app.",
   "author": "@muxinc",
   "license": "MIT",

--- a/src/js/extras/media-clip-selector/index.ts
+++ b/src/js/extras/media-clip-selector/index.ts
@@ -242,6 +242,7 @@ class MediaClipSelector extends globalThis.HTMLElement {
   _dragStart: () => void;
   _dragEnd: () => void;
   _drag: () => void;
+  _suppressClick: boolean = false;
 
   constructor() {
     super();
@@ -373,6 +374,17 @@ class MediaClipSelector extends globalThis.HTMLElement {
   }
 
   dragEnd(): void {
+    // If we were actually dragging a handle, swallow the synthetic click
+    // event the browser fires right after mouseup so it doesn't seek the
+    // player to the handle's release position.
+    if (this.draggingEl) {
+      this._suppressClick = true;
+      // Safety net: clear the flag on the next tick in case the click
+      // never arrives (e.g. mouseup happened outside the wrapper).
+      globalThis.window?.setTimeout(() => {
+        this._suppressClick = false;
+      }, 0);
+    }
     this.initialX = null;
     this.draggingEl = null;
   }
@@ -516,6 +528,12 @@ class MediaClipSelector extends globalThis.HTMLElement {
   }
 
   handleClick(evt: MouseEvent): void {
+    // The click that fires immediately after a drag-mouseup should not seek.
+    if (this._suppressClick) {
+      this._suppressClick = false;
+      return;
+    }
+
     const mousePercent = this.getMousePercent(evt);
     const timestampForClick = mousePercent * this.mediaDuration;
 


### PR DESCRIPTION
- Bump package and lock file versions to 4.3.1-3.
- Add logic to suppress click events immediately following a drag operation in MediaClipSelector to prevent unintended seeking.